### PR TITLE
Add html building to build-all script

### DIFF
--- a/src/build-all.js
+++ b/src/build-all.js
@@ -6,6 +6,8 @@ const buildLessonsXml = require("./xml-lessons-builder");
 const buildQuizTrueFalseXml = require("./xml-quiz3-builder");
 const buildTopicsXml = require("./xml-topics-builder");
 const { createFilePath } = require("./utils/utils");
+const buildTopicsHtml = require("./html-topics-builder");
+const buildLessonsHtml = require("./html-lessons-builder");
 
 buildQuizGift(createFilePath(config, "quizPath"), "output/quiz.gift");
 buildLessonsXml(createFilePath(config, "lessonsPath"), "output/lessons.xml");
@@ -16,3 +18,6 @@ buildQuizTrueFalseXml(
 buildTopicsXml(createFilePath(config, "topicsPath"), "output/topics.xml");
 
 buildQuiz2XML(createFilePath(config, "quizPath"), "output/questions.xml");
+
+buildLessonsHtml(createFilePath(config, "topicsPath"));
+buildTopicsHtml(createFilePath(config, "topicsPath"));

--- a/src/html-lessons-builder.js
+++ b/src/html-lessons-builder.js
@@ -14,7 +14,7 @@ const createContent = (data) =>
 const writeFile = (filename, content) =>
   fs.writeFile(filename, content, writeFileCallback);
 
-const readFileCallback = (path) => (err, data) => {
+const readFileCallback = (filePath) => (err, data) => {
   if (err) {
     console.error("Error reading file:", err);
     return;
@@ -23,13 +23,12 @@ const readFileCallback = (path) => (err, data) => {
   createContent(data).forEach((lesson) => {
     writeFile(
       `output/html/lessons/${lesson.name}.html`,
-      generateHtml(lesson, path, "lessons")
+      generateHtml(lesson, filePath, "lessons")
     );
   });
 };
 
-const main = (path) => fs.readFile(path, "utf8", readFileCallback(path));
+const buildLessonsHtml = (filePath) =>
+  fs.readFile(filePath, "utf8", readFileCallback(filePath));
 
-const inputPath = process.argv[2];
-
-main(inputPath);
+module.exports = buildLessonsHtml;

--- a/src/html-topics-builder.js
+++ b/src/html-topics-builder.js
@@ -14,7 +14,7 @@ const createContent = (data) =>
 const writeFile = (filename, content) =>
   fs.writeFile(filename, content, writeFileCallback);
 
-const readFileCallback = (path) => (err, data) => {
+const readFileCallback = (filePath) => (err, data) => {
   if (err) {
     console.error("Error reading file:", err);
     return;
@@ -23,13 +23,12 @@ const readFileCallback = (path) => (err, data) => {
   createContent(data).forEach((content) => {
     writeFile(
       `output/html/topics/${content.name}.html`,
-      generateHtml(content, path, "topics")
+      generateHtml(content, filePath, "topics")
     );
   });
 };
 
-const main = (path) => fs.readFile(path, "utf8", readFileCallback(path));
+const buildTopicsHtml = (filePath) =>
+  fs.readFile(filePath, "utf8", readFileCallback(filePath));
 
-const inputPath = process.argv[2];
-
-main(inputPath);
+module.exports = buildTopicsHtml;


### PR DESCRIPTION
This pull request includes changes to add HTML generation for lessons and topics, and to improve the readability of the callback function parameter names in the `html-lessons-builder.js` and `html-topics-builder.js` files. The most important changes are summarized below:

### HTML Generation:

* Added `buildLessonsHtml` and `buildTopicsHtml` functions to generate HTML files for lessons and topics respectively, and included these functions in the `src/build-all.js` file. [[1]](diffhunk://#diff-9dca036d79981c7b6e2619fba4c67d89ea04db7a0588181b1a5be8d0b502ed6aR9-R10) [[2]](diffhunk://#diff-9dca036d79981c7b6e2619fba4c67d89ea04db7a0588181b1a5be8d0b502ed6aR21-R23)

### Code Readability:

* Renamed the `path` parameter to `filePath` in the `readFileCallback` function for better clarity in `src/html-lessons-builder.js`. [[1]](diffhunk://#diff-68b6a9221ae464744ba4a2e72ec0e30c10594e52f8b3e6cf3b4d987fea77732cL17-R17) [[2]](diffhunk://#diff-68b6a9221ae464744ba4a2e72ec0e30c10594e52f8b3e6cf3b4d987fea77732cL26-R34)
* Renamed the `path` parameter to `filePath` in the `readFileCallback` function for better clarity in `src/html-topics-builder.js`. [[1]](diffhunk://#diff-d67b04227fcadb0faa74570291070e38a3ae8dff1af971a897a2013ac0544d94L17-R17) [[2]](diffhunk://#diff-d67b04227fcadb0faa74570291070e38a3ae8dff1af971a897a2013ac0544d94L26-R34)