### PR TITLE
Restructure questions building logic

### DIFF
--- a/src/components/generateQuestionsXml.js
+++ b/src/components/generateQuestionsXml.js
@@ -1,136 +1,15 @@
 const fs = require("fs");
 const path = require("path");
 const xmlbuilder = require("xmlbuilder");
-const { parse } = require("../utils/quiz-parser");
 
-const stamp = "moodle.stamp+241010084236+sD8fiO";
-
-const createQuestionBankEntryForMultiChoice =
-  (questionBankEntries) => (question) => {
-    const id = Math.random().toString(36).substring(7);
-    const questionBankEntry = questionBankEntries.ele("question_bank_entry", {
-      id,
-    });
-
-    questionBankEntry.ele("questioncategoryid", "NOT_SURE");
-    questionBankEntry.ele("idnumber", "$@NULL@$");
-    questionBankEntry.ele("ownerid", "NOT_SURE");
-
-    const questionVersion = questionBankEntry.ele("question_version");
-    const questionVersions = questionVersion.ele("question_versions", {
-      id: "NOT_SURE",
-    });
-    questionVersions.ele("version", 1);
-    questionVersions.ele("status", "ready");
-
-    const questionsEle = questionVersions.ele("questions");
-    const questionEle = questionsEle.ele("question", {
-      id: "NOT_SURE",
-    });
-    questionEle.ele("parent", 0);
-    questionEle.ele("name", question.title.trim());
-    questionEle.ele("questiontext", question.question.trim());
-    questionEle.ele("questiontextformat", 1);
-    questionEle.ele("generalfeedback", "");
-    questionEle.ele("generalfeedbackformat", 1);
-    questionEle.ele("defaultmark", "1.0000000");
-    questionEle.ele("penalty", "0.3333333");
-    questionEle.ele("qtype", "multichoice");
-    questionEle.ele("length", 1);
-    questionEle.ele("stamp", stamp);
-    questionEle.ele("timecreated", +new Date());
-    questionEle.ele("timemodified", +new Date());
-    questionEle.ele("createdby", "NOT_SURE");
-    questionEle.ele("modifiedby", "NOT_SURE");
-
-    const pluginQtype = questionEle.ele("plugin_qtype_multichoice_question");
-    const answersEle = pluginQtype.ele("answers");
-
-    const numberOfAnswers = question.answers.length;
-
-    question.answers.forEach((answer) => {
-      const answerEle = answersEle.ele("answer", { id: answer.id });
-      answerEle.ele("answertext", answer.answer.trim());
-      answerEle.ele("answerformat", 0);
-      // 1 for correct, negative fraction for incorrect
-      answerEle.ele(
-        "fraction",
-        answer.correct ? 1 : `-${1 / (numberOfAnswers - 1)}`
-      );
-      answerEle.ele("feedback", "");
-      answerEle.ele("feedbackformat", 0);
-    });
-
-    const multichoiceEle = pluginQtype.ele("multichoice", {
-      id: question.multichoiceid,
-    });
-    multichoiceEle.ele("layout", 0);
-    multichoiceEle.ele("single", 0);
-    multichoiceEle.ele("shuffleanswers", 1);
-    multichoiceEle.ele("correctfeedback", "");
-    multichoiceEle.ele("correctfeedbackformat", 0);
-    multichoiceEle.ele("partiallycorrectfeedback", "");
-    multichoiceEle.ele("partiallycorrectfeedbackformat", 0);
-    multichoiceEle.ele("incorrectfeedback", "");
-    multichoiceEle.ele("incorrectfeedbackformat", 0);
-    multichoiceEle.ele("answernumbering", "none");
-    multichoiceEle.ele("shownumcorrect", 0);
-    multichoiceEle.ele("showstandardinstruction", 1);
-
-    questionEle.ele("plugin_qbank_comment_question").ele("comments");
-    questionEle.ele("plugin_qbank_customfields_question").ele("customfields");
-    questionEle.ele("question_hints");
-    questionEle.ele("tags");
-  };
-
-const generateQuestionCategory = (questionsXml, category, questions) => {
-  const questionCategory = questionsXml.ele("question_category");
-  questionCategory.att("id", category.id);
-  questionCategory.ele("name", category.name.trim());
-  questionCategory.ele("contextid", category.contextid);
-  questionCategory.ele("contextlevel", category.contextlevel);
-  questionCategory.ele("contextinstanceid", category.contextinstanceid);
-  questionCategory.ele("info", category.info || "");
-  questionCategory.ele("infoformat", category.infoformat || 0);
-  questionCategory.ele("stamp", category.stamp);
-  questionCategory.ele("parent", category.parent || 0);
-  questionCategory.ele("sortorder", category.sortorder || 0);
-  questionCategory.ele("idnumber", category.idnumber || "$@NULL@$");
-  const questionBankEntries = questionCategory.ele("question_bank_entries");
-
-  questions.forEach(createQuestionBankEntryForMultiChoice(questionBankEntries));
-};
-
-function generateQuestionsXml(filePath, outputDir) {
-  const file = fs.readFileSync(filePath, "utf8");
-
-  const questionsXml = xmlbuilder.create("question_categories", {
-    encoding: "UTF-8",
-  });
-
-  // TODO: Mock data
-  const category = {
-    id: "160594",
-    name: "top",
-    contextid: "1233447",
-    contextlevel: "50",
-    contextinstanceid: "5412",
-    info: "",
-    infoformat: "0",
-    stamp,
-    parent: "0",
-    sortorder: "0",
-    idnumber: "$@NULL@$",
-  };
-
-  const questions = parse(file);
-
-  generateQuestionCategory(questionsXml, category, questions);
-
-  fs.writeFileSync(
-    path.join(outputDir, "questions.xml"),
-    questionsXml.end({ pretty: true })
-  );
+// Generates questions.xml file inside 'output' directory
+// output\questions.xml
+function generateQuestionsXml(outputDir) {
+  const questionsXml = xmlbuilder
+    .create("question_categories", { encoding: "UTF-8" })
+    .end({ pretty: true });
+  fs.writeFileSync(path.join(outputDir, "questions.xml"), questionsXml);
+  return questionsXml;
 }
 
 module.exports = generateQuestionsXml;

--- a/src/final-mbz-builder.js
+++ b/src/final-mbz-builder.js
@@ -1,15 +1,29 @@
-const path = require('path');
-const { buildGroupsXml } = require('./json-to-mbz/groups');
-const { buildCoursesXml } = require('./json-to-mbz/course/course');
+const fs = require("fs");
+const path = require("path");
+const { buildGroupsXml } = require("./json-to-mbz/groups");
+const { buildCoursesXml } = require("./json-to-mbz/course/course");
+const { buildQuestionsXml } = require("./json-to-mbz/questions");
 
-const finalDir = path.join(__dirname, '..', 'final-mbz');
-const groupsJsonFilePath = "./exported_data/json/export-file-groups-2024-07-01-11-30-19.json";
-const courseJsonFilePath = "./exported_data/json/export-file-sfwd-courses-2024-07-01-11-30-19.json";
+const finalDir = path.join(__dirname, "..", "final-mbz");
 
-function createFinalMoodleBackup(finalDir, groupsJsonFilePath, courseJsonFilePath) {
-    buildGroupsXml(groupsJsonFilePath, finalDir);
-    buildCoursesXml(courseJsonFilePath, finalDir);
+const outputDir = `./output/${finalDir}`;
+
+// Ensure the output directory exists
+if (!fs.existsSync(outputDir)) {
+  fs.mkdirSync(outputDir, { recursive: true });
 }
 
+const groupsJsonFilePath =
+  "./exported_data/json/export-file-groups-2024-07-01-11-30-19.json";
+const courseJsonFilePath =
+  "./exported_data/json/export-file-sfwd-courses-2024-07-01-11-30-19.json";
+const questionsJsonFilePath =
+  "./exported_data/json/export-file-quiz_pro_1-2024-07-01-11-30-19.json";
 
-createFinalMoodleBackup(finalDir, groupsJsonFilePath, courseJsonFilePath);
+function createFinalMoodleBackup() {
+  buildGroupsXml(groupsJsonFilePath, finalDir);
+  buildCoursesXml(courseJsonFilePath, finalDir);
+  buildQuestionsXml(questionsJsonFilePath, finalDir);
+}
+
+createFinalMoodleBackup();

--- a/src/json-to-mbz/questions.js
+++ b/src/json-to-mbz/questions.js
@@ -1,0 +1,136 @@
+const fs = require("fs");
+const path = require("path");
+const xmlbuilder = require("xmlbuilder");
+const { parse } = require("../utils/quiz-parser");
+
+const stamp = "moodle.stamp+241010084236+sD8fiO";
+
+const createQuestionBankEntryForMultiChoice =
+  (questionBankEntries) => (question) => {
+    const id = Math.random().toString(36).substring(7);
+    const questionBankEntry = questionBankEntries.ele("question_bank_entry", {
+      id,
+    });
+
+    questionBankEntry.ele("questioncategoryid", "NOT_SURE");
+    questionBankEntry.ele("idnumber", "$@NULL@$");
+    questionBankEntry.ele("ownerid", "NOT_SURE");
+
+    const questionVersion = questionBankEntry.ele("question_version");
+    const questionVersions = questionVersion.ele("question_versions", {
+      id: "NOT_SURE",
+    });
+    questionVersions.ele("version", 1);
+    questionVersions.ele("status", "ready");
+
+    const questionsEle = questionVersions.ele("questions");
+    const questionEle = questionsEle.ele("question", {
+      id: "NOT_SURE",
+    });
+    questionEle.ele("parent", 0);
+    questionEle.ele("name", question.title.trim());
+    questionEle.ele("questiontext", question.question.trim());
+    questionEle.ele("questiontextformat", 1);
+    questionEle.ele("generalfeedback", "");
+    questionEle.ele("generalfeedbackformat", 1);
+    questionEle.ele("defaultmark", "1.0000000");
+    questionEle.ele("penalty", "0.3333333");
+    questionEle.ele("qtype", "multichoice");
+    questionEle.ele("length", 1);
+    questionEle.ele("stamp", stamp);
+    questionEle.ele("timecreated", +new Date());
+    questionEle.ele("timemodified", +new Date());
+    questionEle.ele("createdby", "NOT_SURE");
+    questionEle.ele("modifiedby", "NOT_SURE");
+
+    const pluginQtype = questionEle.ele("plugin_qtype_multichoice_question");
+    const answersEle = pluginQtype.ele("answers");
+
+    const numberOfAnswers = question.answers.length;
+
+    question.answers.forEach((answer) => {
+      const answerEle = answersEle.ele("answer", { id: answer.id });
+      answerEle.ele("answertext", answer.answer.trim());
+      answerEle.ele("answerformat", 0);
+      // 1 for correct, negative fraction for incorrect
+      answerEle.ele(
+        "fraction",
+        answer.correct ? 1 : `-${1 / (numberOfAnswers - 1)}`
+      );
+      answerEle.ele("feedback", "");
+      answerEle.ele("feedbackformat", 0);
+    });
+
+    const multichoiceEle = pluginQtype.ele("multichoice", {
+      id: question.multichoiceid,
+    });
+    multichoiceEle.ele("layout", 0);
+    multichoiceEle.ele("single", 0);
+    multichoiceEle.ele("shuffleanswers", 1);
+    multichoiceEle.ele("correctfeedback", "");
+    multichoiceEle.ele("correctfeedbackformat", 0);
+    multichoiceEle.ele("partiallycorrectfeedback", "");
+    multichoiceEle.ele("partiallycorrectfeedbackformat", 0);
+    multichoiceEle.ele("incorrectfeedback", "");
+    multichoiceEle.ele("incorrectfeedbackformat", 0);
+    multichoiceEle.ele("answernumbering", "none");
+    multichoiceEle.ele("shownumcorrect", 0);
+    multichoiceEle.ele("showstandardinstruction", 1);
+
+    questionEle.ele("plugin_qbank_comment_question").ele("comments");
+    questionEle.ele("plugin_qbank_customfields_question").ele("customfields");
+    questionEle.ele("question_hints");
+    questionEle.ele("tags");
+  };
+
+const generateQuestionCategory = (questionsXml, category, questions) => {
+  const questionCategory = questionsXml.ele("question_category");
+  questionCategory.att("id", category.id);
+  questionCategory.ele("name", category.name.trim());
+  questionCategory.ele("contextid", category.contextid);
+  questionCategory.ele("contextlevel", category.contextlevel);
+  questionCategory.ele("contextinstanceid", category.contextinstanceid);
+  questionCategory.ele("info", category.info || "");
+  questionCategory.ele("infoformat", category.infoformat || 0);
+  questionCategory.ele("stamp", category.stamp);
+  questionCategory.ele("parent", category.parent || 0);
+  questionCategory.ele("sortorder", category.sortorder || 0);
+  questionCategory.ele("idnumber", category.idnumber || "$@NULL@$");
+  const questionBankEntries = questionCategory.ele("question_bank_entries");
+
+  questions.forEach(createQuestionBankEntryForMultiChoice(questionBankEntries));
+};
+
+function buildQuestionsXml(filePath, outputDir) {
+  const file = fs.readFileSync(filePath, "utf8");
+
+  const questionsXml = xmlbuilder.create("question_categories", {
+    encoding: "UTF-8",
+  });
+
+  // TODO: Mock data
+  const category = {
+    id: "160594",
+    name: "top",
+    contextid: "1233447",
+    contextlevel: "50",
+    contextinstanceid: "5412",
+    info: "",
+    infoformat: "0",
+    stamp,
+    parent: "0",
+    sortorder: "0",
+    idnumber: "$@NULL@$",
+  };
+
+  const questions = parse(file);
+
+  generateQuestionCategory(questionsXml, category, questions);
+
+  fs.writeFileSync(
+    path.join(outputDir, "questions.xml"),
+    questionsXml.end({ pretty: true })
+  );
+}
+
+module.exports = { buildQuestionsXml };

--- a/src/mbz-backup-builder.js
+++ b/src/mbz-backup-builder.js
@@ -33,9 +33,6 @@ const {
 } = require("./components/course/blocks/generateBlocksFiles");
 const { generateGroupsXml } = require("./components/generateGroupsXml");
 
-const { createFilePath } = require("./utils/utils");
-const config = require("../config.json");
-
 function createMoodleBackup(outputDir) {
   // Create subdirectories
   const backupDirs = ["course"];
@@ -61,7 +58,7 @@ function createMoodleBackup(outputDir) {
   generateGroupsXml(outputDir);
   generateMoodleBackup(outputDir);
   generateOutcomesXml(outputDir);
-  generateQuestionsXml(createFilePath(config, "quizPath"), outputDir);
+  generateQuestionsXml(outputDir);
   generateRolesXml(outputDir);
   generateScalesXml(outputDir);
 


### PR DESCRIPTION
This pull request includes several changes to refactor the code for generating XML files and streamline the process of creating a Moodle backup. The most important changes include moving the question XML generation logic to a new file, updating the `generateQuestionsXml` function, and ensuring the output directory exists before creating files.

Refactoring and code organization:

* [`src/components/generateQuestionsXml.js`](diffhunk://#diff-2e773acacd4fc1be9cd802970271cb7b2294c48df2575f52b6b34b3c4acdc5ddL4-R12): Removed the entire question XML generation logic and simplified the `generateQuestionsXml` function to only create an empty `questions.xml` file.
* [`src/json-to-mbz/questions.js`](diffhunk://#diff-72c4c78acc5745e60b5c06dbddf601f2133a683a5c33ca997097450f70a5f4d7R1-R136): Added the question XML generation logic previously in `generateQuestionsXml.js` to this new file, including functions for creating question bank entries and generating question categories.

Updating the Moodle backup process:

* [`src/final-mbz-builder.js`](diffhunk://#diff-b968754597793e32584b1fc9208d8c7f7ca48c2660ea2451b4116da71c64a912L1-R29): Updated the `createFinalMoodleBackup` function to include the new `buildQuestionsXml` function and ensured the output directory exists before generating the backup files.

Minor changes and cleanup:

* [`src/mbz-backup-builder.js`](diffhunk://#diff-c8eae8acbdb84bd17e5a7edc83b7006ff86b8d4e1902b837feccfd79bc95bf8cL36-L38): Updated the `createMoodleBackup` function to use the simplified `generateQuestionsXml` function and removed unused imports. [[1]](diffhunk://#diff-c8eae8acbdb84bd17e5a7edc83b7006ff86b8d4e1902b837feccfd79bc95bf8cL36-L38) [[2]](diffhunk://#diff-c8eae8acbdb84bd17e5a7edc83b7006ff86b8d4e1902b837feccfd79bc95bf8cL64-R61)